### PR TITLE
[rewrite] only fetch one html file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
 This is an simple bash script to download galleries from nhentai, \
 all the downloaded galleries will be stored at ~/nh/{the six digits code} folder, \
 Note that this script will not `mkdir ~/nh` for you, so you'll have to do it yourself or it'll be stored at your current directory
-
-There is a known issue with downloading same image for multiple times, just simply use \
-`find ~/nh -type f -name "*.[1|2|3|4|5|6|7|8|9]*" -delete` to delete those files.

--- a/doc/nhentai_frontend_analysis.md
+++ b/doc/nhentai_frontend_analysis.md
@@ -1,0 +1,116 @@
+
+# Nhentai Frontend Analysis
+By analyze the code of Nhentai's webpage, we can simulate its behaviour and ultimately create a robust way to download the files with the least amount of web requests.
+
+## The URL Rule
+### Forming a usable URL
+By using developer tools on a page of a book on nhentai, in the debugger tab, we search for `url = ` and find this function (prettyprinted):
+```js
+e.url = function () {
+	var t,
+	e;
+	return 'page' === this.type ? (t = 'i', e = this.number.toString()) : 'thumbnail' === this.type ? (t = 't', e = ''.concat(this.number, 't')) : (t = 't', e = ''.concat(this.type)),
+	'https://'.concat(t, '.nhentai.net/galleries/').concat(this.gallery.media_id, '/').concat(e, '.').concat(this.extension)
+}
+```
+This can be (somehow) traslated back to: 
+```js
+e.url = function() {
+	var t, e;
+	if('page' == this.type) {
+		t = 'i';
+		e = `${this.number}`;
+	} else if('thumbnail' === this.type) {
+		t = 't';
+		e = `${this.number}t`;
+	} else {
+		t = 't';
+		e = `${this.type}`;
+	}
+	return `https://${t}.nhentai.net/galleries/${this.gallery.media_id}/${e}.${this.extension}`
+}
+```
+So, for thumbnails, it uses `t` server and get `t${PAGE_NUMBER}.jpg/png/gif` (or so). For the original image that shows on pages, it uses `i` server and get `${PAGE_NUMBER}.jpg/png/gif`. However, this is not the final url that we mostly uses.
+
+### Forming a CDN URL
+By searching for `media_server`, we can find such a code (prettyprinted):
+```js
+return e.get_cdn_url = function (t) {
+	var e = this.options.media_server;
+	return t.replace(
+		/\/\/([it])\d*\./,
+		(function (t, n) {
+			return '//'.concat(n).concat(e, '.')
+		})
+	)
+}
+```
+This code does so: extract the ``//t.` or `//i.` part from the url we constructed above, and add a number indicating the media server after the i/t.
+
+Also, by searching for `media_server`, we can also find the number in the HTML code (prettyprinted):
+```html 
+<script>
+	window._n_app = new App({
+		csrf_token: "...",
+		user: {},
+		blacklisted_tags: null,
+		media_server: 3,
+		ads: {
+			show_popunders: true
+		}
+	});
+</script>
+```
+Worth noticing, the `media_server` property isn't necessarily the same among the cover page `/g/${id}/` and the book pages `/g/${id}/${page_number}`. Sometimes, 404 error also comes since some image is not cached on each server. (e.g., 2024/09/29, `https://i5.nhentai.net/galleries/3050812/18.jpg` is 404, but i3 and i7 has images.) To solve this, we should try another server while downloading failed.
+
+## Fetch The Book Info
+In another `<script>` tag in the HTML code, we can find something like this: 
+```
+window._gallery = JSON.parse("...");
+```
+The `...` part is a JSON string with most character encoded in backslash escape sequence. We can use jq to prettyprint the code. Then, we get something like this: 
+```
+{
+  "id": 529160,
+  "media_id": "3050812",
+  "title": {
+    "english": "[Jido - hanbai-ki (YAMANEKO)] Reguugachi (Made in Abyss)",
+    "japanese": "[Jido-販売機 (YAMANEKO)] レグウガチ (メイドインアビス)",
+    "pretty": "Reguugachi"
+  },
+  "images": {
+    "pages": [
+      {
+        "t": "j",
+        "w": 1280,
+        "h": 1870
+      }, 
+      ...
+    ],
+    "cover": {
+      "t": "j",
+      "w": 350,
+      "h": 512
+    },
+    "thumbnail": {
+      "t": "j",
+      "w": 250,
+      "h": 365
+    }
+  },
+  "scanlator": "",
+  "upload_date": 1725768620,
+  "tags": [
+    {
+      "id": 6346,
+      "type": "language",
+      "name": "japanese",
+      "url": "/language/japanese/",
+      "count": 274762
+    },
+    ...
+  ],
+  "num_pages": 24,
+  "num_favorites": 0
+}
+```

--- a/nh2.sh
+++ b/nh2.sh
@@ -11,13 +11,17 @@ if [ "$1" == "help" ] ; then
 	exit 0
 fi
 
+# kill the whole process group of this script on Ctrl + C
+# ref: https://stackoverflow.com/a/2173421
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
+
 # directory for saving the image
 cd ~/nh
 mkdir $1
 cd $1
 
 # fetch the cover page and save it
-declare COVER_HTML="$(curl -sS https://nhentai.net/g/485643/)"
+declare COVER_HTML="$(wget -q -O - https://nhentai.net/g/$1/)"
 echo "$COVER_HTML" > cover_page.html
 
 # a command to download with auto-retrying
@@ -26,20 +30,28 @@ download-with-auto-retry() {
 	declare URL=$2
 	touch $FILENAME
 
-	curl -sS -o "$FILENAME" "$URL"
-	declare LAST_CURL_DOWNLOAD_RET=$?
-	declare MAX_RETRY=3
+	wget -q -O "$FILENAME" "$URL"
+	declare LAST_WGET_DOWNLOAD_RET=$?
+	declare MAX_RETRY=5
+	declare MEDIA_SERVER_LIST=(3 7 5)
+		# by using `dig i${n}.nhentai.net`, we can see only these three
+		# servers have IPv4 addresses and are thus valid
+
 	for i in $(seq 1 "$MAX_RETRY"); do 
-		# retry if curl didn't run successfully
-		if [ "$LAST_CURL_DOWNLOAD_RET" -eq 0 ]; then
+		# retry if wget didn't run successfully
+		if [ "$LAST_WGET_DOWNLOAD_RET" -eq 0 ]; then
 			break;
-		fi
-		echo "$FILENAME some errors met while downloading. Retrying ($i/$MAX_RETRY)..."
-		curl -sS -o "$FILENAME" "$URL"
+		fi 
+		declare ALTER_MEDIA_SERVER_IDX=$(((i - 1) % ${#MEDIA_SERVER_LIST[@]}))
+		declare ALTER_MEDIA_SERVER=${MEDIA_SERVER_LIST[ALTER_MEDIA_SERVER_IDX]}
+		declare ALTER_URL=$(echo "$URL" | sed -E "s/\/\/(i|t)[0-9]*\./\/\/\1${ALTER_MEDIA_SERVER}./")
+		echo "$FILENAME error. Retrying with media_server=$ALTER_MEDIA_SERVER ($i/$MAX_RETRY)..."
+		wget -q -O "$FILENAME" "$ALTER_URL"
+		LAST_WGET_DOWNLOAD_RET=$?
 	done
 
 	# tell the user that some file is downloaded
-	if [ "$LAST_CURL_DOWNLOAD_RET" -eq 0 ]; then
+	if [ "$LAST_WGET_DOWNLOAD_RET" -eq 0 ]; then
 		echo "$FILENAME downloaded"
 	else
 		echo "$FILENAME failed to download"
@@ -49,19 +61,31 @@ download-with-auto-retry() {
 # extract a list of images that we need to download
 # make enter after each html tag 
 # -> grep the urls 
-#	 - pattern: cover.jpg/png/gif, and t${number}.jpg/png/gif for thumbnails
+#        - pattern: cover.jpg/png/gif, and t${number}.jpg/png/gif for thumbnails
 # -> convert thumbnail filenames to normal files
 # -> uniquify the links with awk
 #    - notice: there may still be multiple urls for book covers
 declare IMAGE_URLS="$(echo "$COVER_HTML" \
 	| sed -E 's/>/\n/g' \
-	| grep -oEe 'https://t[0-9]+.nhentai\.net/galleries/[0-9]+/([0-9]+t|cover)\.[a-zA-Z]+' \
-	| sed -E 's/t(\.[a-zA-Z]{1,10})$/\1/g' \
+	| grep -oEe 'https://t[0-9]+.nhentai\.net/galleries/[0-9]+/[0-9]+t\.[a-zA-Z]+' \
+	| sed -E 's/t(\.[a-zA-Z]{1,10})$/\1/g' | sed -E 's/\/\/t([0-9]+)\./\/\/i\1./' \
 	| awk '!a[$0]++'
 )"
 
 # download each image
-declare JOBS=""
+declare JOBS=()
+declare MAX_JOB_COUNT=20
+
+update-jobs() {
+	declare UPDATED=()
+	for PID in "${JOBS[@]}"; do 
+		if ps -p "$PID" >> /dev/null ; then
+			UPDATED+=("$PID")
+		fi
+	done;
+	JOBS=("${UPDATED[@]}")
+}
+
 for URL in $IMAGE_URLS; do 
 	# extract filename 
 	declare FILENAME="$(echo "$URL" | sed -E 's/.*\/([^\/]+)/\1/' )"
@@ -71,13 +95,20 @@ for URL in $IMAGE_URLS; do
 		continue
 	fi
 
+	# wait while there are too many downloading in parallel
+	while [ "${#JOBS[@]}" -ge "$MAX_JOB_COUNT" ]; do 
+		update-jobs
+		sleep 1;
+	done
+
 	# download the file with auto-retrying
 	download-with-auto-retry $FILENAME $URL &
-	JOBS="$JOBS $!"
+	JOBS+=("$!")
 done;
 
 # do not exit the program before all the jobs done
-for PID in $JOBS; do 
-	wait "$PID";
+while [ -n "$JOBS" ]; do 
+	# echo waiting for "${JOBS[@]}"
+	update-jobs;
 done;
 

--- a/nh2_old.sh
+++ b/nh2_old.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+if [ "$1" == "help" ] ; then
+	echo This is a script used to download and nhentai as pictures
+	echo
+	echo "(./)nh2.sh [NUMBER|help]"
+	echo
+	echo NUMBER is the magic number of the gallery
+	echo or you may as well use help to print out this help messege
+	exit 0
+fi
+
+cd ~/nh
+mkdir $1
+cd $1
+
+declare JOBS=""
+
+declare max_page=0
+
+touch tmp.html
+
+for i in $(seq 1 500)
+do
+#skip if image already exists, should be alright
+	if [ -e $i.jpg ]; then
+		continue
+	fi
+	if [ -e $i.png ]; then
+		continue
+	fi
+	if [ -e $i.gif ]; then
+		continue
+	fi
+
+#download html of nhentai.net/g/NUMBER/$i
+	curl -s https://nhentai.net/g/$1/$i/ > tmp.html
+
+#check if it's 404 or not, break if it is
+	# echo $(grep -o -e "404 - Not Found" tmp.html)
+	if [ "$(grep -o -e "404 - Not Found" tmp.html)" == "404 - Not Found" ]; then
+		max_page=$(($i-1))
+		break
+	fi
+	# echo $i
+
+
+#grep to get the source of image
+	img=$(grep -o -e "https://i[1|2|3|4|5|6|7|8|9].nhentai.net/galleries/[0|1|2|3|4|5|6|7|8|9]*/[1|2|3|4|5|6|7|8|9][0|1|2|3|4|5|6|7|8|9]*.[j|p|g][p|n|i][g|f]" tmp.html)
+	# echo $img
+
+#wget to download it
+	file_type=${img#*.}
+	file_type=${file_type#*.}
+	file_type=${file_type#*.}
+	if [ ! -f $i.$file_type ]; then
+		wget -q $img &
+		JOBS="$JOBS $!"
+	fi
+	echo "$1: $i"
+done
+
+#echo $max_page
+
+# recheck
+for k in $(seq 1 50)
+do
+	flag=0
+	sleep 1
+	for j in $(seq 1 10)
+	do
+		flag=0
+		for i in $(seq 1 $max_page)
+		do
+			#skip if file already exists, ought to be right
+			if [ -e $i.jpg ]; then
+				continue
+			fi
+			if [ -e $i.png ]; then
+				continue
+			fi
+			if [ -e $i.gif ]; then
+				continue
+			fi
+
+			#flaged since there's still image loss
+			flag=1
+
+			#resend html request
+			curl -s https://nhentai.net/g/$1/$i/ > tmp.html
+			img=$(grep -o -e "https://i[1|2|3|4|5|6|7|8|9].nhentai.net/galleries/[0|1|2|3|4|5|6|7|8|9]*/[1|2|3|4|5|6|7|8|9][0|1|2|3|4|5|6|7|8|9]*.[j|p|g][p|n|i][g|f]" tmp.html)
+
+			#get img type
+			wget -q $img &
+			JOBS="$JOBS $!"
+			# echo "$i "
+		done
+
+		if [ $flag -eq 0 ]; then
+			break
+		fi
+	done
+	if [ $flag -eq 0 ]; then
+		break
+	fi
+done
+
+rm tmp.html
+# rm tmp*.html
+# ls | grep -P "[0|1|2|3|4|5|6|7|8|9]$" | xargs -d"\n" rm
+
+for PID in $JOBS; do 
+	wait $PID;
+done;

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# kill the whole process group of this script on Ctrl + C
+# ref: https://stackoverflow.com/a/2173421
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
+
+IDS="529160 528484 520419 514200 501156 501062 498434 498070 495835 493857 491474 486140 479564 464382 456202 447645 433951 429934 424562 422683 414786 400733 391273 391040"
+
+if [ ! -e ~/nh ]; then 
+	mkdir ~/nh
+fi
+
+echo "nh2.sh started at $(date +%Y%m%d-%H%M%S.%N)" > testlog
+for i in $IDS; do 
+	./nh2.sh "$i"
+	rm ~/nh/"$i"/cover_page.html
+done
+echo "nh2.sh ended at $(date +%Y%m%d-%H%M%S.%N)" >> testlog
+
+mv ~/nh ~/nh_new
+mkdir ~/nh
+
+echo "nh2_old.sh started at $(date +%Y%m%d-%H%M%S.%N)" >> testlog
+for i in $IDS; do 
+	./nh2_old.sh "$i"
+done
+echo "nh2_old.sh ended at $(date +%Y%m%d-%H%M%S.%N)" >> testlog
+
+find ~/nh -type f -name "*.[1|2|3|4|5|6|7|8|9]*" -delete
+
+diff -r ~/nh ~/nh_new

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,7 @@
 # ref: https://stackoverflow.com/a/2173421
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
+# IDS="529160"
 IDS="529160 528484 520419 514200 501156 501062 498434 498070 495835 493857 491474 486140 479564 464382 456202 447645 433951 429934 424562 422683 414786 400733 391273 391040"
 
 if [ ! -e ~/nh ]; then 
@@ -28,4 +29,9 @@ echo "nh2_old.sh ended at $(date +%Y%m%d-%H%M%S.%N)" >> testlog
 
 find ~/nh -type f -name "*.[1|2|3|4|5|6|7|8|9]*" -delete
 
-diff -r ~/nh ~/nh_new
+diff -r ~/nh ~/nh_new >> testlog
+
+echo 
+echo 
+echo "Here is the testlog: "
+cat testlog


### PR DESCRIPTION
Previous Pull Request: https://github.com/chengyin30069/nh-project/pull/1

This time, I've undergone some further research before this pull request:
  - It'll be helpful if we can figure out how Nhentai works. Thus, I've slightly reverse-engineered their front-end code. To keep the notes of our analysis in the repo, for now, I wrote a markdown file in the `/doc` directory.
    - In the analysis, I showed that it's possible to translate a thumbnail url to a orignal image url. Also, I found that the media_server 5 is the main problem causing failures - it's a issue from nhentai's site, not ours. Sometimes when we visit a page from a book, the server tells us to use server 5 even if the page is not backup there.
  - I've written a script to test the performance and output results, which calls both the old and new code and compares the `~/nh` folder after that.

Here is a log from `test.sh`.
```text
nh2.sh started at 20240930-051859.879859233
nh2.sh ended at 20240930-052644.520317895
nh2_old.sh started at 20240930-052644.526001679
nh2_old.sh ended at 20240930-053639.247219463
```
There are two points from above:
  - The new code takes 7m44s, while the old code takes 9m55s. Thus, the performance is raised by 27% - which can be imporved further if we change the ${MAX_JOB_COUNT} variable. 
  - No diff shows here. Therefore, the code should have no error now - I have a confidence of 9/10.